### PR TITLE
feat: add energy meter fields and isPassenger to Trip model

### DIFF
--- a/apps/api/prisma/migrations/20260420115800_add_energy_and_passenger_fields/migration.sql
+++ b/apps/api/prisma/migrations/20260420115800_add_energy_and_passenger_fields/migration.sql
@@ -1,0 +1,11 @@
+-- AlterTable
+ALTER TABLE "trips" ADD COLUMN     "isPassenger" BOOLEAN,
+ADD COLUMN     "energy1Start" DOUBLE PRECISION,
+ADD COLUMN     "energy1End" DOUBLE PRECISION,
+ADD COLUMN     "energy1Consumption" DOUBLE PRECISION,
+ADD COLUMN     "energy2Start" DOUBLE PRECISION,
+ADD COLUMN     "energy2End" DOUBLE PRECISION,
+ADD COLUMN     "energy2Consumption" DOUBLE PRECISION,
+ADD COLUMN     "energy3Start" DOUBLE PRECISION,
+ADD COLUMN     "energy3End" DOUBLE PRECISION,
+ADD COLUMN     "energy3Consumption" DOUBLE PRECISION;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -85,6 +85,18 @@ model Trip {
   handoverDate   String?    // YYYY-MM-DD
   handoverTime   String?    // HH:mm
   sectionCount   Int?
+  isPassenger    Boolean?
+
+  // Energy meter fields
+  energy1Start       Float?
+  energy1End         Float?
+  energy1Consumption Float?
+  energy2Start       Float?
+  energy2End         Float?
+  energy2Consumption Float?
+  energy3Start       Float?
+  energy3End         Float?
+  energy3Consumption Float?
 
   user        User         @relation(fields: [userId], references: [id], onDelete: Cascade)
   voiceInputs VoiceInput[]

--- a/packages/contracts/src/schemas/trip.schema.ts
+++ b/packages/contracts/src/schemas/trip.schema.ts
@@ -46,6 +46,16 @@ export const TripSchema = z.object({
   handoverDate: ISODate.nullish(),
   handoverTime: HHmm.nullish(),
   sectionCount: z.number().int().nullish(),
+  isPassenger: z.boolean().nullish(),
+  energy1Start: z.number().nullish(),
+  energy1End: z.number().nullish(),
+  energy1Consumption: z.number().nullish(),
+  energy2Start: z.number().nullish(),
+  energy2End: z.number().nullish(),
+  energy2Consumption: z.number().nullish(),
+  energy3Start: z.number().nullish(),
+  energy3End: z.number().nullish(),
+  energy3Consumption: z.number().nullish(),
 });
 export type Trip = z.infer<typeof TripSchema>;
 
@@ -72,6 +82,16 @@ export const CreateTripDtoSchema = z.object({
   handoverDate: ISODate.optional(),
   handoverTime: HHmm.optional(),
   sectionCount: z.number().int().optional(),
+  isPassenger: z.boolean().optional(),
+  energy1Start: z.number().optional(),
+  energy1End: z.number().optional(),
+  energy1Consumption: z.number().optional(),
+  energy2Start: z.number().optional(),
+  energy2End: z.number().optional(),
+  energy2Consumption: z.number().optional(),
+  energy3Start: z.number().optional(),
+  energy3End: z.number().optional(),
+  energy3Consumption: z.number().optional(),
 });
 export type CreateTripDto = z.infer<typeof CreateTripDtoSchema>;
 


### PR DESCRIPTION
- Add isPassenger Boolean? to Trip model in Prisma schema
- Add energy1/2/3 Start, End, Consumption Float? fields to Trip
- Add corresponding nullish()/optional() fields to TripSchema and CreateTripDtoSchema in contracts
- Add migration 20260420115800_add_energy_and_passenger_fields