### PR TITLE
feat: add trip export to PDF and Excel

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -28,6 +28,8 @@
     "passport-local": "^1.0.0",
     "@fastify/static": "^7.0.4",
     "bcryptjs": "^2.4.3",
+    "pdfkit": "^0.15.0",
+    "exceljs": "^4.4.0",
     "zod": "^3.23.8",
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.1"
@@ -36,6 +38,7 @@
     "@nestjs/cli": "^10.4.2",
     "@nestjs/schematics": "^10.1.4",
     "@types/bcryptjs": "^2.4.6",
+    "@types/pdfkit": "^0.13.6",
     "@types/node": "^20.14.10",
     "@types/passport-jwt": "^4.0.1",
     "@types/passport-local": "^1.0.38",

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -7,6 +7,7 @@ import { TripsModule } from './trips/trips.module';
 import { VoiceModule } from './voice/voice.module';
 import { SalaryModule } from './salary/salary.module';
 import { SummaryModule } from './summary/summary.module';
+import { ExportModule } from './export/export.module';
 
 @Module({
   imports: [
@@ -18,6 +19,7 @@ import { SummaryModule } from './summary/summary.module';
     VoiceModule,
     SalaryModule,
     SummaryModule,
+    ExportModule,
   ],
 })
 export class AppModule {}

--- a/apps/api/src/export/export.controller.ts
+++ b/apps/api/src/export/export.controller.ts
@@ -1,0 +1,43 @@
+import { Controller, Get, Param, Query, Res, UseGuards } from '@nestjs/common';
+import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
+import { FastifyReply } from 'fastify';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { CurrentUser, JwtUser } from '../common/current-user.decorator';
+import { ExportService } from './export.service';
+
+@ApiTags('export')
+@ApiBearerAuth()
+@UseGuards(JwtAuthGuard)
+@Controller('export')
+export class ExportController {
+  constructor(private readonly exportService: ExportService) {}
+
+  @Get('trips/pdf')
+  async exportPeriodPdf(
+    @CurrentUser() user: JwtUser,
+    @Query('from') from: string,
+    @Query('to') to: string,
+    @Res() reply: FastifyReply,
+  ) {
+    return this.exportService.exportPeriodPdf(user.userId, from, to, reply);
+  }
+
+  @Get('trips/xlsx')
+  async exportPeriodXlsx(
+    @CurrentUser() user: JwtUser,
+    @Query('from') from: string,
+    @Query('to') to: string,
+    @Res() reply: FastifyReply,
+  ) {
+    return this.exportService.exportPeriodXlsx(user.userId, from, to, reply);
+  }
+
+  @Get('trips/:id/pdf')
+  async exportOneTripPdf(
+    @CurrentUser() user: JwtUser,
+    @Param('id') id: string,
+    @Res() reply: FastifyReply,
+  ) {
+    return this.exportService.exportOneTripPdf(user.userId, id, reply);
+  }
+}

--- a/apps/api/src/export/export.module.ts
+++ b/apps/api/src/export/export.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { ExportController } from './export.controller';
+import { ExportService } from './export.service';
+
+@Module({
+  controllers: [ExportController],
+  providers: [ExportService],
+})
+export class ExportModule {}

--- a/apps/api/src/export/export.service.ts
+++ b/apps/api/src/export/export.service.ts
@@ -1,0 +1,256 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { FastifyReply } from 'fastify';
+import * as PDFDocument from 'pdfkit';
+import * as ExcelJS from 'exceljs';
+import { PrismaService } from '../prisma/prisma.service';
+import { TripTypeLabelMap } from '@railcrew/contracts';
+
+type TripRecord = {
+  id: string;
+  routeFrom: string;
+  routeTo: string;
+  date: string;
+  endDate: string | null;
+  startTime: string;
+  endTime: string;
+  durationMinutes: number;
+  tripType: string;
+  notes: string | null;
+  trainNumber: string | null;
+  trainWeight: number | null;
+  axleCount: number | null;
+  locoModel: string | null;
+  locoNumber: string | null;
+  appearanceDate: string | null;
+  appearanceTime: string | null;
+  handoverDate: string | null;
+  handoverTime: string | null;
+  energy1Start: number | null;
+  energy1End: number | null;
+  energy1Consumption: number | null;
+  energy2Start: number | null;
+  energy2End: number | null;
+  energy2Consumption: number | null;
+  energy3Start: number | null;
+  energy3End: number | null;
+  energy3Consumption: number | null;
+  isPassenger: boolean | null;
+};
+
+function formatDur(minutes: number): string {
+  const h = Math.floor(minutes / 60);
+  const m = minutes % 60;
+  return m > 0 ? `${h} ч ${m} мин` : `${h} ч`;
+}
+
+function sectionConsumption(start: number | null, end: number | null, stored: number | null): number | null {
+  if (stored != null) return stored;
+  if (start != null && end != null) return end - start;
+  return null;
+}
+
+function totalEnergy(trip: TripRecord): number | null {
+  const sections = [
+    sectionConsumption(trip.energy1Start, trip.energy1End, trip.energy1Consumption),
+    sectionConsumption(trip.energy2Start, trip.energy2End, trip.energy2Consumption),
+    sectionConsumption(trip.energy3Start, trip.energy3End, trip.energy3Consumption),
+  ].filter((v): v is number => v != null);
+  return sections.length > 0 ? sections.reduce((a, b) => a + b, 0) : null;
+}
+
+function tripTypeLabel(type: string): string {
+  return TripTypeLabelMap[type as keyof typeof TripTypeLabelMap] ?? type;
+}
+
+@Injectable()
+export class ExportService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  private async getTripsForPeriod(userId: string, from: string, to: string): Promise<TripRecord[]> {
+    return this.prisma.trip.findMany({
+      where: { userId, date: { gte: from, lte: to } },
+      orderBy: [{ date: 'asc' }, { startTime: 'asc' }],
+    }) as Promise<TripRecord[]>;
+  }
+
+  private async getOneTrip(userId: string, id: string): Promise<TripRecord> {
+    const trip = await this.prisma.trip.findFirst({ where: { id, userId } });
+    if (!trip) throw new NotFoundException('Поездка не найдена');
+    return trip as TripRecord;
+  }
+
+  async exportPeriodPdf(userId: string, from: string, to: string, reply: FastifyReply): Promise<void> {
+    const trips = await this.getTripsForPeriod(userId, from, to);
+
+    const chunks: Buffer[] = [];
+    const doc = new PDFDocument({ margin: 40, size: 'A4' });
+    doc.on('data', (chunk: Buffer) => chunks.push(chunk));
+
+    await new Promise<void>((resolve) => {
+      doc.on('end', () => resolve());
+
+      doc.fontSize(16).text(`Отчёт по поездкам: ${from} — ${to}`, { align: 'center' });
+      doc.moveDown(0.5);
+      doc.fontSize(11).text(`Всего поездок: ${trips.length}`, { align: 'center' });
+      doc.moveDown(1);
+
+      for (const trip of trips) {
+        this.renderTripBlock(doc, trip);
+        doc.moveDown(0.5);
+        doc.moveTo(doc.page.margins.left, doc.y)
+          .lineTo(doc.page.width - doc.page.margins.right, doc.y)
+          .strokeColor('#cccccc')
+          .stroke();
+        doc.moveDown(0.5);
+      }
+
+      doc.end();
+    });
+
+    const buffer = Buffer.concat(chunks);
+    reply
+      .header('Content-Type', 'application/pdf')
+      .header('Content-Disposition', `attachment; filename="trips-${from}-${to}.pdf"`)
+      .send(buffer);
+  }
+
+  async exportOneTripPdf(userId: string, id: string, reply: FastifyReply): Promise<void> {
+    const trip = await this.getOneTrip(userId, id);
+
+    const chunks: Buffer[] = [];
+    const doc = new PDFDocument({ margin: 40, size: 'A4' });
+    doc.on('data', (chunk: Buffer) => chunks.push(chunk));
+
+    await new Promise<void>((resolve) => {
+      doc.on('end', () => resolve());
+      this.renderTripBlock(doc, trip);
+      doc.end();
+    });
+
+    const buffer = Buffer.concat(chunks);
+    reply
+      .header('Content-Type', 'application/pdf')
+      .header('Content-Disposition', `attachment; filename="trip-${id}.pdf"`)
+      .send(buffer);
+  }
+
+  private renderTripBlock(doc: InstanceType<typeof PDFDocument>, trip: TripRecord): void {
+    doc.fontSize(13).fillColor('#000000').text(`${trip.routeFrom} — ${trip.routeTo}`);
+    doc.fontSize(10).fillColor('#555555').text(
+      `${trip.date}${trip.endDate && trip.endDate !== trip.date ? ` → ${trip.endDate}` : ''}  ·  ${tripTypeLabel(trip.tripType)}`,
+    );
+    doc.moveDown(0.3);
+
+    if (trip.trainNumber) doc.text(`Номер поезда: ${trip.trainNumber}`);
+    if (trip.locoModel || trip.locoNumber) {
+      doc.text(`Локомотив: ${[trip.locoModel, trip.locoNumber].filter(Boolean).join(' ')}`);
+    }
+    if (trip.trainWeight != null) doc.text(`Вес поезда: ${trip.trainWeight} т`);
+    if (trip.axleCount != null) doc.text(`Осей: ${trip.axleCount}`);
+    if (trip.appearanceDate && trip.appearanceTime) {
+      doc.text(`Явка: ${trip.appearanceDate} ${trip.appearanceTime}`);
+    }
+    if (trip.handoverDate && trip.handoverTime) {
+      doc.text(`Сдача: ${trip.handoverDate} ${trip.handoverTime}`);
+    }
+
+    doc.text(`Длительность: ${formatDur(trip.durationMinutes)}`);
+
+    const e1c = sectionConsumption(trip.energy1Start, trip.energy1End, trip.energy1Consumption);
+    const e2c = sectionConsumption(trip.energy2Start, trip.energy2End, trip.energy2Consumption);
+    const e3c = sectionConsumption(trip.energy3Start, trip.energy3End, trip.energy3Consumption);
+
+    if (trip.energy1Start != null || trip.energy1End != null || e1c != null) {
+      doc.text(`Сек.1: нач. ${trip.energy1Start ?? '—'}, кон. ${trip.energy1End ?? '—'}, расход ${e1c != null ? e1c.toFixed(0) : '—'} кВт·ч`);
+    }
+    if (trip.energy2Start != null || trip.energy2End != null || e2c != null) {
+      doc.text(`Сек.2: нач. ${trip.energy2Start ?? '—'}, кон. ${trip.energy2End ?? '—'}, расход ${e2c != null ? e2c.toFixed(0) : '—'} кВт·ч`);
+    }
+    if (trip.energy3Start != null || trip.energy3End != null || e3c != null) {
+      doc.text(`Сек.3: нач. ${trip.energy3Start ?? '—'}, кон. ${trip.energy3End ?? '—'}, расход ${e3c != null ? e3c.toFixed(0) : '—'} кВт·ч`);
+    }
+
+    const total = totalEnergy(trip);
+    if (total != null) {
+      doc.text(`Итого расход: ${total.toFixed(0)} кВт·ч`);
+    }
+
+    if (trip.notes) {
+      doc.moveDown(0.2);
+      doc.fillColor('#333333').text(`Примечание: ${trip.notes}`);
+    }
+    doc.fillColor('#000000');
+  }
+
+  async exportPeriodXlsx(userId: string, from: string, to: string, reply: FastifyReply): Promise<void> {
+    const trips = await this.getTripsForPeriod(userId, from, to);
+
+    const wb = new ExcelJS.Workbook();
+    const ws = wb.addWorksheet('Поездки');
+
+    ws.columns = [
+      { header: 'Дата', key: 'date', width: 12 },
+      { header: 'Маршрут', key: 'route', width: 30 },
+      { header: 'Тип', key: 'type', width: 14 },
+      { header: 'Локомотив', key: 'loco', width: 18 },
+      { header: 'Номер поезда', key: 'trainNum', width: 14 },
+      { header: 'Вес, т', key: 'weight', width: 10 },
+      { header: 'Осей', key: 'axles', width: 8 },
+      { header: 'Явка', key: 'appearance', width: 18 },
+      { header: 'Сдача', key: 'handover', width: 18 },
+      { header: 'Длительность', key: 'duration', width: 14 },
+      { header: 'Сек.1 нач.', key: 'e1s', width: 10 },
+      { header: 'Сек.1 кон.', key: 'e1e', width: 10 },
+      { header: 'Сек.1 расход', key: 'e1c', width: 12 },
+      { header: 'Сек.2 нач.', key: 'e2s', width: 10 },
+      { header: 'Сек.2 кон.', key: 'e2e', width: 10 },
+      { header: 'Сек.2 расход', key: 'e2c', width: 12 },
+      { header: 'Сек.3 нач.', key: 'e3s', width: 10 },
+      { header: 'Сек.3 кон.', key: 'e3e', width: 10 },
+      { header: 'Сек.3 расход', key: 'e3c', width: 12 },
+      { header: 'Итого расход', key: 'etotal', width: 14 },
+      { header: 'Примечание', key: 'notes', width: 30 },
+    ];
+
+    const headerRow = ws.getRow(1);
+    headerRow.font = { bold: true };
+    headerRow.fill = { type: 'pattern', pattern: 'solid', fgColor: { argb: 'FFD9E1F2' } };
+
+    for (const trip of trips) {
+      const e1c = sectionConsumption(trip.energy1Start, trip.energy1End, trip.energy1Consumption);
+      const e2c = sectionConsumption(trip.energy2Start, trip.energy2End, trip.energy2Consumption);
+      const e3c = sectionConsumption(trip.energy3Start, trip.energy3End, trip.energy3Consumption);
+      const etotal = totalEnergy(trip);
+
+      ws.addRow({
+        date: trip.date,
+        route: `${trip.routeFrom} — ${trip.routeTo}`,
+        type: tripTypeLabel(trip.tripType),
+        loco: [trip.locoModel, trip.locoNumber].filter(Boolean).join(' ') || null,
+        trainNum: trip.trainNumber,
+        weight: trip.trainWeight,
+        axles: trip.axleCount,
+        appearance: trip.appearanceDate && trip.appearanceTime ? `${trip.appearanceDate} ${trip.appearanceTime}` : null,
+        handover: trip.handoverDate && trip.handoverTime ? `${trip.handoverDate} ${trip.handoverTime}` : null,
+        duration: formatDur(trip.durationMinutes),
+        e1s: trip.energy1Start,
+        e1e: trip.energy1End,
+        e1c,
+        e2s: trip.energy2Start,
+        e2e: trip.energy2End,
+        e2c,
+        e3s: trip.energy3Start,
+        e3e: trip.energy3End,
+        e3c,
+        etotal,
+        notes: trip.notes,
+      });
+    }
+
+    const buffer = await wb.xlsx.writeBuffer() as Buffer;
+    reply
+      .header('Content-Type', 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet')
+      .header('Content-Disposition', `attachment; filename="trips-${from}-${to}.xlsx"`)
+      .send(buffer);
+  }
+}

--- a/apps/mobile/app/(tabs)/index.tsx
+++ b/apps/mobile/app/(tabs)/index.tsx
@@ -1,6 +1,8 @@
 import { useEffect, useMemo, useState } from 'react';
-import { View, Text, StyleSheet, TouchableOpacity, ScrollView } from 'react-native';
+import { View, Text, StyleSheet, TouchableOpacity, ScrollView, Alert, ActivityIndicator } from 'react-native';
 import { format, startOfWeek, endOfWeek, startOfMonth, endOfMonth } from 'date-fns';
+import * as FileSystem from 'expo-file-system';
+import * as Sharing from 'expo-sharing';
 import { useTripsStore } from '@/store/trips.store';
 import { useAuthStore } from '@/store/auth.store';
 import {
@@ -10,6 +12,7 @@ import {
 } from '@/services/storage.service';
 import { TripTypeLabelMap } from '@railcrew/contracts';
 import { formatDuration } from '@/utils/date';
+import { exportApi } from '@/services/api.service';
 
 type PeriodFilter = 'DAY' | 'WEEK' | 'MONTH';
 
@@ -111,6 +114,7 @@ export default function DashboardScreen() {
   const [period, setPeriod] = useState<PeriodFilter>('MONTH');
   const [salaryRule, setSalaryRule] = useState<LocalSalaryRule | null>(null);
   const [settings, setSettings] = useState<LocalSettings | null>(null);
+  const [exporting, setExporting] = useState(false);
 
   useEffect(() => {
     loadLocal();
@@ -206,9 +210,71 @@ export default function DashboardScreen() {
 
   const greeting = profile?.firstName ? `Привет, ${profile.firstName}` : 'Сводка';
 
+  const { from: monthFrom, to: monthTo } = getPeriodBounds('MONTH');
+
+  function handleExportMonth(format: 'pdf' | 'xlsx') {
+    Alert.alert(
+      'Экспорт за месяц',
+      `Скачать отчёт за ${monthFrom} — ${monthTo} в формате ${format.toUpperCase()}?`,
+      [
+        { text: 'Отмена', style: 'cancel' },
+        {
+          text: 'Скачать',
+          onPress: async () => {
+            setExporting(true);
+            try {
+              if (format === 'pdf') {
+                const data = await exportApi.downloadPeriodPdf(monthFrom, monthTo);
+                const path = `${FileSystem.cacheDirectory}trips-${monthFrom}-${monthTo}.pdf`;
+                await FileSystem.writeAsStringAsync(path, Buffer.from(data).toString('base64'), {
+                  encoding: FileSystem.EncodingType.Base64,
+                });
+                await Sharing.shareAsync(path, { mimeType: 'application/pdf', UTI: 'com.adobe.pdf' });
+              } else {
+                const data = await exportApi.downloadPeriodXlsx(monthFrom, monthTo);
+                const path = `${FileSystem.cacheDirectory}trips-${monthFrom}-${monthTo}.xlsx`;
+                await FileSystem.writeAsStringAsync(path, Buffer.from(data).toString('base64'), {
+                  encoding: FileSystem.EncodingType.Base64,
+                });
+                await Sharing.shareAsync(path, {
+                  mimeType: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+                  UTI: 'org.openxmlformats.spreadsheetml.sheet',
+                });
+              }
+            } catch {
+              Alert.alert('Ошибка', 'Не удалось экспортировать данные');
+            } finally {
+              setExporting(false);
+            }
+          },
+        },
+      ],
+    );
+  }
+
+  function handleExportPress() {
+    Alert.alert('Экспорт за месяц', 'Выберите формат', [
+      { text: 'Отмена', style: 'cancel' },
+      { text: 'PDF', onPress: () => handleExportMonth('pdf') },
+      { text: 'Excel', onPress: () => handleExportMonth('xlsx') },
+    ]);
+  }
+
   return (
     <ScrollView style={s.screen} contentContainerStyle={{ paddingBottom: 100 }}>
-      <Text style={s.greeting}>{greeting}</Text>
+      <View style={s.greetingRow}>
+        <Text style={s.greeting}>{greeting}</Text>
+        <TouchableOpacity
+          style={s.exportMonthBtn}
+          onPress={handleExportPress}
+          disabled={exporting}
+          activeOpacity={0.75}
+        >
+          {exporting
+            ? <ActivityIndicator color={C.blue} size="small" />
+            : <Text style={s.exportMonthBtnText}>Экспорт за месяц</Text>}
+        </TouchableOpacity>
+      </View>
 
       {/* Period tabs */}
       <View style={s.periodRow}>
@@ -522,10 +588,18 @@ function TripRow({ trip, last }: { trip: LocalTrip; last: boolean }) {
 const s = StyleSheet.create({
   screen: { flex: 1, backgroundColor: C.bg, padding: 16 },
 
-  greeting: {
-    color: C.textPrimary, fontSize: 22, fontWeight: '700',
+  greetingRow: {
+    flexDirection: 'row', justifyContent: 'space-between', alignItems: 'flex-end',
     marginTop: 48, marginBottom: 12,
   },
+  greeting: {
+    color: C.textPrimary, fontSize: 22, fontWeight: '700', flex: 1,
+  },
+  exportMonthBtn: {
+    borderWidth: 1, borderColor: C.blue, borderRadius: 10,
+    paddingHorizontal: 12, paddingVertical: 7, marginLeft: 12,
+  },
+  exportMonthBtnText: { color: C.blue, fontSize: 13, fontWeight: '600' },
 
   // Period
   periodRow: { flexDirection: 'row', gap: 8, marginBottom: 16 },

--- a/apps/mobile/app/trip/[id].tsx
+++ b/apps/mobile/app/trip/[id].tsx
@@ -8,8 +8,10 @@ import DateTimePicker, { DateTimePickerEvent } from '@react-native-community/dat
 import { format } from 'date-fns';
 import { ru } from 'date-fns/locale';
 import { router, useLocalSearchParams } from 'expo-router';
+import * as FileSystem from 'expo-file-system';
+import * as Sharing from 'expo-sharing';
 import { useTripsStore } from '@/store/trips.store';
-import { tripsApi } from '@/services/api.service';
+import { tripsApi, exportApi } from '@/services/api.service';
 import { LocalTrip, LocalCreateTripDto } from '@/services/storage.service';
 import { TripType, TripTypeLabelMap, UpdateTripDtoSchema } from '@railcrew/contracts';
 import { formatDuration, formatDateRu } from '@/utils/date';
@@ -54,6 +56,7 @@ export default function TripDetailScreen() {
   const [saving, setSaving] = useState(false);
   const [draft, setDraft] = useState<Partial<LocalTrip>>({});
   const [pickerMode, setPickerMode] = useState<PickerMode>(null);
+  const [exporting, setExporting] = useState(false);
 
   useEffect(() => {
     const local = trips.find((t) => t.id === id || t.localId === id);
@@ -177,6 +180,34 @@ export default function TripDetailScreen() {
     } finally {
       setSaving(false);
     }
+  }
+
+  function handleExportPress() {
+    if (!trip?.id) {
+      Alert.alert('Экспорт недоступен', 'Поездка ещё не синхронизирована с сервером.');
+      return;
+    }
+    Alert.alert('Экспорт поездки', 'Выберите формат', [
+      { text: 'Отмена', style: 'cancel' },
+      {
+        text: 'PDF',
+        onPress: async () => {
+          setExporting(true);
+          try {
+            const data = await exportApi.downloadTripPdf(trip.id!);
+            const path = `${FileSystem.cacheDirectory}trip-${trip.id}.pdf`;
+            await FileSystem.writeAsStringAsync(path, Buffer.from(data).toString('base64'), {
+              encoding: FileSystem.EncodingType.Base64,
+            });
+            await Sharing.shareAsync(path, { mimeType: 'application/pdf', UTI: 'com.adobe.pdf' });
+          } catch {
+            Alert.alert('Ошибка', 'Не удалось экспортировать поездку');
+          } finally {
+            setExporting(false);
+          }
+        },
+      },
+    ]);
   }
 
   function handleDeletePress() {
@@ -407,6 +438,17 @@ export default function TripDetailScreen() {
             activeOpacity={0.75}
           >
             <Text style={s.duplicateBtnText}>Дублировать поездку</Text>
+          </TouchableOpacity>
+
+          <TouchableOpacity
+            style={s.exportBtn}
+            onPress={handleExportPress}
+            disabled={exporting}
+            activeOpacity={0.75}
+          >
+            {exporting
+              ? <ActivityIndicator color="#3b82f6" />
+              : <Text style={s.exportBtnText}>Экспорт (PDF)</Text>}
           </TouchableOpacity>
         </>
       ) : (
@@ -769,9 +811,15 @@ const s = StyleSheet.create({
 
   duplicateBtn: {
     borderWidth: 1, borderColor: '#334155', borderRadius: 12, padding: 14,
-    alignItems: 'center', marginBottom: 40,
+    alignItems: 'center', marginBottom: 10,
   },
   duplicateBtnText: { color: '#94a3b8', fontSize: 15, fontWeight: '600' },
+
+  exportBtn: {
+    borderWidth: 1, borderColor: '#1d4ed8', borderRadius: 12, padding: 14,
+    alignItems: 'center', marginBottom: 40,
+  },
+  exportBtnText: { color: '#3b82f6', fontSize: 15, fontWeight: '600' },
 
   iosOverlay: { flex: 1, justifyContent: 'flex-end', backgroundColor: 'rgba(0,0,0,0.5)' },
   iosSheet: { backgroundColor: '#1e293b', borderTopLeftRadius: 20, borderTopRightRadius: 20, paddingBottom: 32 },

--- a/apps/mobile/src/services/api.service.ts
+++ b/apps/mobile/src/services/api.service.ts
@@ -63,6 +63,16 @@ export const summaryApi = {
     http.get<Summary>('/summary', { params: query }).then((r) => r.data),
 };
 
+// Export
+export const exportApi = {
+  downloadPeriodPdf: (from: string, to: string) =>
+    http.get<ArrayBuffer>('/export/trips/pdf', { params: { from, to }, responseType: 'arraybuffer' }).then((r) => r.data),
+  downloadPeriodXlsx: (from: string, to: string) =>
+    http.get<ArrayBuffer>('/export/trips/xlsx', { params: { from, to }, responseType: 'arraybuffer' }).then((r) => r.data),
+  downloadTripPdf: (id: string) =>
+    http.get<ArrayBuffer>(`/export/trips/${id}/pdf`, { responseType: 'arraybuffer' }).then((r) => r.data),
+};
+
 // Salary rules
 export const salaryApi = {
   create: (dto: CreateSalaryRuleDto) =>


### PR DESCRIPTION
- Backend: ExportModule with GET /export/trips/pdf, /export/trips/xlsx, /export/trips/:id/pdf
- PDF via pdfkit, Excel via exceljs; includes route, date, type, loco, train number, weight, axes, appearance/handover, duration, energy by sections, total consumption, notes
- Mobile: export button on trip detail screen (PDF via expo-sharing)
- Mobile: "Экспорт за месяц" button on dashboard (PDF or Excel via expo-sharing)

Closes #1

🤖 Generated with [Claude Code](https://claude.ai/code)